### PR TITLE
Fix workflow after branch rename

### DIFF
--- a/.github/workflows/deploy_mdbook.yml
+++ b/.github/workflows/deploy_mdbook.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   ci:


### PR DESCRIPTION
The deployment github action was still triggered by changes to the old default branch. Update it to use main instead.