### PR TITLE
Add `Terminator` and `ty`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,5 +13,6 @@
 #![cfg_attr(not(feature = "default"), feature(rustc_private))]
 
 pub mod mir;
+pub mod ty;
 
 pub mod very_unstable;

--- a/src/mir.rs
+++ b/src/mir.rs
@@ -5,6 +5,6 @@ pub use crate::very_unstable::middle::mir::{
     InlineAsmOperand, Local, LocalDecl, LocalInfo, LocalKind, Location, MirPhase, MirSource,
     NullOp, Operand, Place, PlaceRef, ProjectionElem, ProjectionKind, Promoted, RetagKind, Rvalue,
     Safety, SourceInfo, SourceScope, SourceScopeData, SourceScopeLocalData, Statement,
-    StatementKind, UnOp, UserTypeProjection, UserTypeProjections, VarBindingForm, VarDebugInfo,
-    VarDebugInfoContents,
+    StatementKind, Terminator, TerminatorKind, UnOp, UserTypeProjection, UserTypeProjections,
+    VarBindingForm, VarDebugInfo, VarDebugInfoContents,
 };

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -1,0 +1,6 @@
+pub use crate::very_unstable::middle::ty::{
+    subst::{GenericArgKind, InternalSubsts, Subst, SubstsRef},
+    AdtDef, ClosureKind, ClosureSubsts, Const, ConstKind, FieldDef, FloatTy, GenericParamDef,
+    GenericParamDefKind, IntTy, ParamEnv, Predicate, ProjectionTy, Ty, TyKind, UintTy, Unevaluated,
+    UpvarSubsts, VariantDef, VariantDef,
+};


### PR DESCRIPTION
Adds missing `Terminator` and `TerminatorKind` apis to `mir`.

Also adds the start of a `ty` module which captures other common apis, I tried to only add 'uncontroversial' types to it, we can discuss further additions.
