### PR TITLE
remove erroneous duplicate import.

### DIFF
--- a/src/ty.rs
+++ b/src/ty.rs
@@ -2,5 +2,5 @@ pub use crate::very_unstable::middle::ty::{
     subst::{GenericArgKind, InternalSubsts, Subst, SubstsRef},
     AdtDef, ClosureKind, ClosureSubsts, Const, ConstKind, FieldDef, FloatTy, GenericParamDef,
     GenericParamDefKind, IntTy, ParamEnv, Predicate, ProjectionTy, Ty, TyKind, UintTy, Unevaluated,
-    UpvarSubsts, VariantDef, VariantDef,
+    UpvarSubsts, VariantDef,
 };


### PR DESCRIPTION
For some reason, the code had a duplicate import, which meant that attempting to build the crate failed.