### PR TITLE
Create tooling for end-to-end testing

### DIFF
--- a/.github/scripts/run_own_tests.sh
+++ b/.github/scripts/run_own_tests.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Execute our own set of tests using a local `compiletest` tool based on `ui_test`.
+set -e
+set -u
+
+# Where we will store the SMIR tools (Optional).
+TOOLS_BIN="${TOOLS_BIN:-"/tmp/smir/bin"}"
+# Assume we are inside SMIR repository
+SMIR_PATH=$(git rev-parse --show-toplevel)
+export RUST_BACKTRACE=1
+
+# Build stable_mir tools
+function build_smir_tools() {
+  pushd "${SMIR_PATH}"
+  cargo +nightly build -Z unstable-options --out-dir "${TOOLS_BIN}"
+  export PATH="${TOOLS_BIN}":"${PATH}"
+}
+
+# Run tests
+function run_tests() {
+  SUITES=(
+    "sanity-checks pass"
+    "fixme fail"
+  )
+  for suite_cfg in "${SUITES[@]}"; do
+    # Hack to work on older bash like the ones on MacOS.
+    suite_pair=($suite_cfg)
+    suite=${suite_pair[0]}
+    mode=${suite_pair[1]}
+    echo "#### Running suite: ${suite} mode: ${mode}"
+    compiletest \
+        --driver-path="${TOOLS_BIN}/test-drive" \
+        --mode=${mode} \
+        --src-base="tests/${suite}" \
+        --output-dir="target/tests/" \
+        --no-capture
+  done
+}
+
+build_smir_tools
+run_tests

--- a/.github/scripts/run_own_tests.sh
+++ b/.github/scripts/run_own_tests.sh
@@ -20,7 +20,7 @@ function build_smir_tools() {
 function run_tests() {
   SUITES=(
     "sanity-checks pass"
-    "fixme fail"
+    "fixme fix-me"
   )
   for suite_cfg in "${SUITES[@]}"; do
     # Hack to work on older bash like the ones on MacOS.

--- a/.github/scripts/run_rustc_tests.sh
+++ b/.github/scripts/run_rustc_tests.sh
@@ -87,7 +87,9 @@ function run_tests() {
       --android-cross-path= \
       --target=${HOST} \
       --llvm-filecheck="${FILE_CHECK}" \
-      --channel=nightly
+      --channel=nightly \
+      --target-rustcflags="--smir-check" \
+      --host-rustcflags="--smir-check"
   done
 }
 

--- a/.github/scripts/run_rustc_tests.sh
+++ b/.github/scripts/run_rustc_tests.sh
@@ -1,35 +1,96 @@
 #!/usr/bin/env bash
 
+# Run rustc test suites using our test driver using nightly.
+# This script leverages the rustc's repo compiletest crate.
+#
+# The suites configuration should match:
+# https://github.com/rust-lang/rust/blob/master/src/bootstrap/test.rs
+
 set -e
 set -u
-
-# Location of a rust repository. Clone one if path doesn't exist.
-RUST_REPO="${RUST_REPO:?Missing path to rust repository. Set RUST_REPO}"
-# Where we will store the SMIR tools (Optional).
-TOOLS_BIN="${TOOLS_BIN:-"/tmp/smir/bin"}"
-# Assume we are inside SMIR repository
-SMIR_PATH=$(git rev-parse --show-toplevel)
 export RUST_BACKTRACE=1
 
-pushd "${SMIR_PATH}"
-cargo build -Z unstable-options --out-dir "${TOOLS_BIN}"
-export PATH="${TOOLS_BIN}":"${PATH}"
+# Location of a rust repository. Clone one if path doesn't exist.
+RUST_REPO="${RUST_REPO:-"/tmp/rustc"}"
 
-if [[ ! -e "${RUST_REPO}" ]]; then
-  mkdir -p "$(dirname ${RUST_REPO})"
-  git clone --depth 1 https://github.com/rust-lang/rust.git "${RUST_REPO}"
-fi
+# Where we will store the SMIR tools (Optional).
+TOOLS_BIN="${TOOLS_BIN:-"/tmp/smir/bin"}"
 
-pushd "${RUST_REPO}"
-SUITES=(
-  # Match https://github.com/rust-lang/rust/blob/master/src/bootstrap/test.rs for now
-  "tests/ui/cfg yolo"
-)
-for suite_cfg in "${SUITES[@]}"; do
-  # Hack to work on older bash like the ones on MacOS.
-  suite_pair=($suite_cfg)
-  suite=${suite_pair[0]}
-  mode=${suite_pair[1]}
-  echo "${suite_cfg} pair: $suite_pair mode: $mode"
-  compiletest --driver-path="${TOOLS_BIN}/test-drive" --mode=${mode} --src-base="${suite}" --output-dir="${RUST_REPO}/build"
-done
+# Assume we are inside SMIR repository
+SMIR_PATH=$(git rev-parse --show-toplevel)
+
+# Build stable_mir tools
+function build_smir_tools() {
+  pushd "${SMIR_PATH}"
+  cargo +nightly build -Z unstable-options --out-dir "${TOOLS_BIN}"
+  export PATH="${TOOLS_BIN}":"${PATH}"
+}
+
+# Set up rustc repository
+function setup_rustc_repo() {
+  if [[ ! -e "${RUST_REPO}" ]]; then
+    mkdir -p "$(dirname ${RUST_REPO})"
+    git clone -b master https://github.com/rust-lang/rust.git "${RUST_REPO}"
+    pushd "${RUST_REPO}"
+    commit="$(rustc +nightly -vV | awk '/^commit-hash/ { print $2 }')"
+    git checkout ${commit}
+    git submodule init -- "${RUST_REPO}/library/stdarch"
+    git submodule update
+  else
+    pushd "${RUST_REPO}"
+  fi
+}
+
+function run_tests() {
+  # Run the following suite configuration for now (test suite + mode)
+  SUITES=(
+    "codegen codegen"
+    "codegen-units codegen-units"
+    # -- The suites below are failing because of fully qualified paths for standard library
+    # E.g.:
+    # -    _10 = _eprint(move _11) -> [return: bb6, unwind unreachable];
+    # +    _10 = std::io::_eprint(move _11) -> [return: bb6, unwind unreachable];
+    #
+    #"ui ui"
+    #"mir-opt mir-opt"
+    #"pretty pretty" -- 2 failing tests
+  )
+
+  SYSROOT=$(rustc +nightly --print sysroot)
+  PY_PATH=$(type -P python3)
+  HOST=$(rustc +nightly -vV | awk '/^host/ { print $2 }')
+  FILE_CHECK="$(which FileCheck-12 || which FileCheck-13 || which FileCheck-14)"
+
+  for suite_cfg in "${SUITES[@]}"; do
+    # Hack to work on older bash like the ones on MacOS.
+    suite_pair=($suite_cfg)
+    suite=${suite_pair[0]}
+    mode=${suite_pair[1]}
+
+    echo "#### Running suite: ${suite} mode: ${mode}"
+    cargo +nightly run -p compiletest -- \
+      --compile-lib-path="${SYSROOT}/lib" \
+      --run-lib-path="${SYSROOT}/lib"\
+      --python="${PY_PATH}" \
+      --rustc-path="${TOOLS_BIN}/test-drive" \
+      --mode=${mode} \
+      --suite="${suite}" \
+      --src-base="tests/${suite}" \
+      --build-base="$(pwd)/build/${HOST}/stage1/tests/${suite}" \
+      --sysroot-base="$SYSROOT" \
+      --stage-id=stage1-${HOST} \
+      --cc= \
+      --cxx= \
+      --cflags= \
+      --cxxflags= \
+      --llvm-components= \
+      --android-cross-path= \
+      --target=${HOST} \
+      --llvm-filecheck="${FILE_CHECK}" \
+      --channel=nightly
+  done
+}
+
+build_smir_tools
+setup_rustc_repo
+run_tests

--- a/.github/scripts/run_rustc_tests.sh
+++ b/.github/scripts/run_rustc_tests.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+
+# Location of a rust repository. Clone one if path doesn't exist.
+RUST_REPO="${RUST_REPO:?Missing path to rust repository. Set RUST_REPO}"
+# Where we will store the SMIR tools (Optional).
+TOOLS_BIN="${TOOLS_BIN:-"/tmp/smir/bin"}"
+# Assume we are inside SMIR repository
+SMIR_PATH=$(git rev-parse --show-toplevel)
+export RUST_BACKTRACE=1
+
+pushd "${SMIR_PATH}"
+cargo +smir build -Z unstable-options --out-dir "${TOOLS_BIN}"
+export PATH="${TOOLS_BIN}":"${PATH}"
+
+if [[ ! -e "${RUST_REPO}" ]]; then
+  mkdir -p "$(dirname ${RUST_REPO})"
+  git clone --depth 1 https://github.com/rust-lang/rust.git "${RUST_REPO}"
+fi
+
+pushd "${RUST_REPO}"
+SUITES=(
+  # Match https://github.com/rust-lang/rust/blob/master/src/bootstrap/test.rs for now
+  "tests/ui/cfg ui"
+)
+for suite_cfg in "${SUITES[@]}"; do
+  # Hack to work on older bash like the ones on MacOS.
+  suite_pair=($suite_cfg)
+  suite=${suite_pair[0]}
+  mode=${suite_pair[1]}
+  echo "${suite_cfg} pair: $suite_pair mode: $mode"
+  compiletest --driver-path="${TOOLS_BIN}/test-drive" --mode=${mode} --src-base="${suite}" --output-path "${RUST_REPO}/build"
+done

--- a/.github/scripts/run_rustc_tests.sh
+++ b/.github/scripts/run_rustc_tests.sh
@@ -12,7 +12,7 @@ SMIR_PATH=$(git rev-parse --show-toplevel)
 export RUST_BACKTRACE=1
 
 pushd "${SMIR_PATH}"
-cargo +smir build -Z unstable-options --out-dir "${TOOLS_BIN}"
+cargo build -Z unstable-options --out-dir "${TOOLS_BIN}"
 export PATH="${TOOLS_BIN}":"${PATH}"
 
 if [[ ! -e "${RUST_REPO}" ]]; then

--- a/.github/scripts/run_rustc_tests.sh
+++ b/.github/scripts/run_rustc_tests.sh
@@ -23,7 +23,7 @@ fi
 pushd "${RUST_REPO}"
 SUITES=(
   # Match https://github.com/rust-lang/rust/blob/master/src/bootstrap/test.rs for now
-  "tests/ui/cfg ui"
+  "tests/ui/cfg yolo"
 )
 for suite_cfg in "${SUITES[@]}"; do
   # Hack to work on older bash like the ones on MacOS.
@@ -31,5 +31,5 @@ for suite_cfg in "${SUITES[@]}"; do
   suite=${suite_pair[0]}
   mode=${suite_pair[1]}
   echo "${suite_cfg} pair: $suite_pair mode: $mode"
-  compiletest --driver-path="${TOOLS_BIN}/test-drive" --mode=${mode} --src-base="${suite}" --output-path "${RUST_REPO}/build"
+  compiletest --driver-path="${TOOLS_BIN}/test-drive" --mode=${mode} --src-base="${suite}" --output-dir="${RUST_REPO}/build"
 done

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,3 +29,5 @@ jobs:
         env:
           RUST_REPO: "/tmp/rustc"
           TOOLS_BIN: "/tmp/smir/bin"
+        # Don't fail CI for now. See: https://github.com/rust-lang/project-stable-mir/issues/39
+        continue-on-error: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,21 @@
+name: Run compiler tests
+
+on:
+  schedule:
+    - cron: "0 6 * * *"  # Run daily at 06:00 UTC
+  workflow_dispatch:     # Allow manual dispatching
+  pull_request:
+
+jobs:
+  compile-test:
+    name: Rust Compiler Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Test
+        run: ./.github/scripts/run_rustc_tests.sh
+        env:
+          RUST_REPO: "/tmp/rustc"
+          TOOLS_BIN: "/tmp/smir/bin"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,7 +14,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Test
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+
+      - name: Test local suites
+        run: ./.github/scripts/run_own_tests.sh
+        env:
+          TOOLS_BIN: "/tmp/smir/bin"
+
+      - name: Test rustc suites
         run: ./.github/scripts/run_rustc_tests.sh
         env:
           RUST_REPO: "/tmp/rustc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,12 @@
+# Cargo workspace for utility tools used to check stable-mir in CI
+[workspace]
+resolver = "2"
+members = [
+    "tools/compiletest",
+    "tools/test-drive",
+]
+
+exclude = [
+    "build",
+    "target",
+]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = ["llvm-tools-preview", "rustc-dev", "rust-src", "rustfmt"]

--- a/tests/fixme/associated-items/methods.rs
+++ b/tests/fixme/associated-items/methods.rs
@@ -1,0 +1,83 @@
+//! Example derived from <https://doc.rust-lang.org/reference/items/associated-items.html>
+#![feature(box_into_inner)]
+
+use std::pin::Pin;
+use std::rc::Rc;
+use std::sync::Arc;
+
+#[derive(Default, Debug)]
+struct Example {
+    inner: String,
+}
+
+type Alias = Example;
+trait Trait {
+    type Output;
+}
+impl Trait for Example {
+    type Output = Example;
+}
+
+#[allow(unused)]
+impl Example {
+    pub fn by_value(self: Self) {
+        self.by_ref("by_val");
+    }
+
+    pub fn by_ref(self: &Self, source: &str) {
+        println!("{source}: {}", self.inner);
+    }
+
+    pub fn by_ref_mut(self: &mut Self) {
+        self.inner = "by_ref_mut".to_string();
+        self.by_ref("mut");
+    }
+
+    pub fn by_box(self: Box<Self>) {
+        self.by_ref("by_box");
+        Box::into_inner(self).by_value();
+    }
+
+    pub fn by_rc(self: Rc<Self>) {
+        self.by_ref("by_rc");
+    }
+
+    pub fn by_arc(self: Arc<Self>) {
+        self.by_ref("by_arc");
+    }
+
+    pub fn by_pin(self: Pin<&Self>) {
+        self.by_ref("by_pin");
+    }
+
+    pub fn explicit_type(self: Arc<Example>) {
+        self.by_ref("explicit");
+    }
+
+    pub fn with_lifetime<'a>(self: &'a Self) {
+        self.by_ref("lifetime");
+    }
+
+    pub fn nested<'a>(self: &mut &'a Arc<Rc<Box<Alias>>>) {
+        self.by_ref("nested");
+    }
+
+    pub fn via_projection(self: <Example as Trait>::Output) {
+        self.by_ref("via_projection");
+    }
+
+    pub fn from(name: String) -> Self {
+        Example { inner: name }
+    }
+}
+
+fn main() {
+    let example = Example::from("Hello".to_string());
+    example.by_value();
+
+    let boxed = Box::new(Example::default());
+    boxed.by_box();
+
+    Example::default().by_ref_mut();
+    Example::default().with_lifetime();
+}

--- a/tests/sanity-checks/simple/simple_lib.rs
+++ b/tests/sanity-checks/simple/simple_lib.rs
@@ -1,0 +1,23 @@
+//! Just a simple library
+
+pub struct Point {
+    pub x: i64,
+    pub y: i64,
+}
+
+impl Point {
+    pub fn distance(&self, other: &Point) -> u64 {
+        let (x_dist, x_over) = (self.x - other.x).overflowing_pow(2);
+        let (y_dist, y_over) = (self.y - other.y).overflowing_pow(2);
+        if y_over | x_over {
+            panic!("overflow");
+        }
+
+        let dist = (x_dist as u64 + y_dist as u64) >> 1;
+        dist
+    }
+
+    pub fn distance_root(&self) -> u64 {
+        self.distance(&Point { x: 0, y: 0 })
+    }
+}

--- a/tools/compiletest/Cargo.toml
+++ b/tools/compiletest/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.0.0"
 edition = "2021"
 
 [dependencies]
-compiletest_rs = { version = "0.10.0", features = [ "rustc" ] }
+ui_test = "0.20.0"
 clap = { version = "4.1.3", features = ["derive"] }
 
 [package.metadata.rust-analyzer]

--- a/tools/compiletest/Cargo.toml
+++ b/tools/compiletest/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "compiletest"
+description = "Run tests using compiletest-rs"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+compiletest_rs = { version = "0.10.0", features = [ "rustc" ] }
+clap = { version = "4.1.3", features = ["derive"] }
+
+[package.metadata.rust-analyzer]
+# This crate uses #[feature(rustc_private)].
+# See https://github.com/rust-analyzer/rust-analyzer/pull/7891
+rustc_private = true

--- a/tools/compiletest/build.rs
+++ b/tools/compiletest/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+use std::path::PathBuf;
+
+pub fn main() {
+    // Add rustup to the rpath in order to properly link with the correct rustc version.
+    let rustup_home = env::var("RUSTUP_HOME").unwrap();
+    let toolchain = env::var("RUSTUP_TOOLCHAIN").unwrap();
+    let rustc_lib: PathBuf = [&rustup_home, "toolchains", &toolchain, "lib"]
+        .iter()
+        .collect();
+    println!(
+        "cargo:rustc-link-arg-bin=compiletest=-Wl,-rpath,{}",
+        rustc_lib.display()
+    );
+    println!("cargo:rustc-env=RUSTC_LIB_PATH={}", rustc_lib.display());
+}

--- a/tools/compiletest/src/args.rs
+++ b/tools/compiletest/src/args.rs
@@ -1,3 +1,4 @@
+use std::ffi::OsString;
 /// Create our own parser and build the Config from it.
 use std::fmt::Debug;
 use std::path::PathBuf;
@@ -16,6 +17,8 @@ pub enum Mode {
     Fail,
     /// Run the tests, but always pass them as long as all annotations are satisfied and stderr files match.
     Yolo,
+    /// The test passes a full execution of `cargo build`
+    CargoPass,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -26,7 +29,7 @@ pub struct Args {
     src_base: PathBuf,
 
     /// The mode according to ui_test modes.
-    #[arg(long, default_value="yolo")]
+    #[arg(long, default_value = "yolo")]
     mode: Mode,
 
     /// Path for the stable-mir driver.
@@ -39,17 +42,26 @@ pub struct Args {
 
     #[arg(long)]
     pub verbose: bool,
+
+    /// Run test-driver on verbose mode to print test outputs.
+    #[arg(long)]
+    pub no_capture: bool,
 }
 
 impl From<Mode> for ui_test::Mode {
     /// Use rustc configuration as default but override arguments to fit our use case.
     fn from(mode: Mode) -> ui_test::Mode {
         match mode {
-            Mode::Pass => { ui_test::Mode::Pass }
-            Mode::Run => { ui_test::Mode::Run { exit_code: 0 }}
-            Mode::Panic => { ui_test::Mode::Panic }
-            Mode::Fail => { ui_test::Mode::Fail { require_patterns: false, rustfix: RustfixMode::Disabled }}
-            Mode::Yolo => { ui_test::Mode::Yolo { rustfix: RustfixMode::Disabled }}
+            Mode::Pass | Mode::CargoPass => ui_test::Mode::Pass,
+            Mode::Run => ui_test::Mode::Run { exit_code: 0 },
+            Mode::Panic => ui_test::Mode::Panic,
+            Mode::Fail => ui_test::Mode::Fail {
+                require_patterns: false,
+                rustfix: RustfixMode::Disabled,
+            },
+            Mode::Yolo => ui_test::Mode::Yolo {
+                rustfix: RustfixMode::Disabled,
+            },
         }
     }
 }
@@ -57,14 +69,47 @@ impl From<Mode> for ui_test::Mode {
 impl From<Args> for Config {
     /// Use rustc configuration as default but override arguments to fit our use case.
     fn from(args: Args) -> Config {
-        let mut config = Config::rustc(args.src_base);
-        config.program = CommandBuilder::rustc();
-        config.program.program = args.driver_path;
-        config.program.args.push("--check-smir".into());
+        let mut config = if matches!(args.mode, Mode::CargoPass) {
+            cargo_config(&args)
+        } else {
+            driver_config(&args)
+        };
+        config.filter(r"\[T-DRIVE\].*\n", "");
         config.mode = ui_test::Mode::from(args.mode);
         config.output_conflict_handling = OutputConflictHandling::Error("Should Fail".to_string());
         config.out_dir = args.output_dir;
         //config.run_lib_path = PathBuf::from(env!("RUSTC_LIB_PATH"));
         config
     }
+}
+
+fn rustc_flags(args: &Args) -> Vec<OsString> {
+    let mut flags = vec!["--check-smir".into()];
+    if args.verbose || args.no_capture {
+        flags.push("--verbose".into());
+    }
+    flags
+}
+
+/// Configure cargo tests that will run the test-driver instead of rustc.
+fn cargo_config(args: &Args) -> Config {
+    let mut config = Config::cargo(args.src_base.clone());
+    config.program.envs.push((
+        "RUST".into(),
+        Some(args.driver_path.clone().into_os_string()),
+    ));
+    config.program.envs.push((
+        "CARGO_ENCODED_RUSTFLAGS".into(),
+        Some(rustc_flags(args).join(&OsString::from("\x1f")).into()),
+    ));
+    config
+}
+
+/// Configure tests that will invoke the test-driver directly as rustc.
+fn driver_config(args: &Args) -> Config {
+    let mut config = Config::rustc(args.src_base.clone());
+    config.program = CommandBuilder::rustc();
+    config.program.program = args.driver_path.clone();
+    config.program.args = rustc_flags(args);
+    config
 }

--- a/tools/compiletest/src/args.rs
+++ b/tools/compiletest/src/args.rs
@@ -1,6 +1,22 @@
-use compiletest_rs::Config;
+/// Create our own parser and build the Config from it.
 use std::fmt::Debug;
 use std::path::PathBuf;
+use ui_test::{CommandBuilder, Config, OutputConflictHandling, RustfixMode};
+
+#[derive(Copy, Clone, Debug, clap::ValueEnum)]
+/// Decides what is expected of each test's exit status.
+pub enum Mode {
+    /// The test passes a full execution of the rustc driver
+    Pass,
+    /// The test produces an executable binary that can get executed on the host
+    Run,
+    /// The rustc driver panicked
+    Panic,
+    /// The rustc driver emitted an error
+    Fail,
+    /// Run the tests, but always pass them as long as all annotations are satisfied and stderr files match.
+    Yolo,
+}
 
 #[derive(Debug, clap::Parser)]
 #[command(version, name = "compiletest")]
@@ -9,9 +25,9 @@ pub struct Args {
     #[arg(long)]
     src_base: PathBuf,
 
-    /// The mode according to compiletest modes.
-    #[arg(long)]
-    mode: String,
+    /// The mode according to ui_test modes.
+    #[arg(long, default_value="yolo")]
+    mode: Mode,
 
     /// Path for the stable-mir driver.
     #[arg(long)]
@@ -19,22 +35,36 @@ pub struct Args {
 
     /// Path for where the output should be stored.
     #[arg(long)]
-    output_path: PathBuf,
+    output_dir: PathBuf,
 
     #[arg(long)]
-    verbose: bool,
+    pub verbose: bool,
+}
+
+impl From<Mode> for ui_test::Mode {
+    /// Use rustc configuration as default but override arguments to fit our use case.
+    fn from(mode: Mode) -> ui_test::Mode {
+        match mode {
+            Mode::Pass => { ui_test::Mode::Pass }
+            Mode::Run => { ui_test::Mode::Run { exit_code: 0 }}
+            Mode::Panic => { ui_test::Mode::Panic }
+            Mode::Fail => { ui_test::Mode::Fail { require_patterns: false, rustfix: RustfixMode::Disabled }}
+            Mode::Yolo => { ui_test::Mode::Yolo { rustfix: RustfixMode::Disabled }}
+        }
+    }
 }
 
 impl From<Args> for Config {
+    /// Use rustc configuration as default but override arguments to fit our use case.
     fn from(args: Args) -> Config {
-        let mut config = Config::default();
-        config.mode = args.mode.parse().expect("Invalid mode");
-        config.src_base = args.src_base;
-        config.rustc_path = args.driver_path;
-        config.build_base = args.output_path;
-        config.verbose = args.verbose;
-        config.run_lib_path = PathBuf::from(env!("RUSTC_LIB_PATH"));
-        config.link_deps();
+        let mut config = Config::rustc(args.src_base);
+        config.program = CommandBuilder::rustc();
+        config.program.program = args.driver_path;
+        config.program.args.push("--check-smir".into());
+        config.mode = ui_test::Mode::from(args.mode);
+        config.output_conflict_handling = OutputConflictHandling::Error("Should Fail".to_string());
+        config.out_dir = args.output_dir;
+        //config.run_lib_path = PathBuf::from(env!("RUSTC_LIB_PATH"));
         config
     }
 }

--- a/tools/compiletest/src/args.rs
+++ b/tools/compiletest/src/args.rs
@@ -1,0 +1,40 @@
+use compiletest_rs::Config;
+use std::fmt::Debug;
+use std::path::PathBuf;
+
+#[derive(Debug, clap::Parser)]
+#[command(version, name = "compiletest")]
+pub struct Args {
+    /// The path where all tests are
+    #[arg(long)]
+    src_base: PathBuf,
+
+    /// The mode according to compiletest modes.
+    #[arg(long)]
+    mode: String,
+
+    /// Path for the stable-mir driver.
+    #[arg(long)]
+    driver_path: PathBuf,
+
+    /// Path for where the output should be stored.
+    #[arg(long)]
+    output_path: PathBuf,
+
+    #[arg(long)]
+    verbose: bool,
+}
+
+impl From<Args> for Config {
+    fn from(args: Args) -> Config {
+        let mut config = Config::default();
+        config.mode = args.mode.parse().expect("Invalid mode");
+        config.src_base = args.src_base;
+        config.rustc_path = args.driver_path;
+        config.build_base = args.output_path;
+        config.verbose = args.verbose;
+        config.run_lib_path = PathBuf::from(env!("RUSTC_LIB_PATH"));
+        config.link_deps();
+        config
+    }
+}

--- a/tools/compiletest/src/main.rs
+++ b/tools/compiletest/src/main.rs
@@ -2,8 +2,8 @@
 
 mod args;
 
-use std::process::ExitCode;
 use clap::Parser;
+use std::process::ExitCode;
 use ui_test::{status_emitter, Config};
 
 fn main() -> ExitCode {
@@ -31,5 +31,9 @@ fn main() -> ExitCode {
         ui_test::default_per_file_config,
         (text, status_emitter::Gha::<true> { name }),
     );
-    if result.is_ok() { ExitCode::SUCCESS } else { ExitCode::FAILURE }
+    if result.is_ok() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
 }

--- a/tools/compiletest/src/main.rs
+++ b/tools/compiletest/src/main.rs
@@ -1,0 +1,12 @@
+//! Run compiletest on a given folder.
+
+mod args;
+use clap::Parser;
+use compiletest_rs::Config;
+
+fn main() {
+    let args = args::Args::parse();
+    println!("args: ${args:?}");
+    let cfg = Config::from(args);
+    compiletest_rs::run_tests(&cfg);
+}

--- a/tools/compiletest/src/main.rs
+++ b/tools/compiletest/src/main.rs
@@ -1,12 +1,35 @@
 //! Run compiletest on a given folder.
 
 mod args;
-use clap::Parser;
-use compiletest_rs::Config;
 
-fn main() {
+use std::process::ExitCode;
+use clap::Parser;
+use ui_test::{status_emitter, Config};
+
+fn main() -> ExitCode {
     let args = args::Args::parse();
-    println!("args: ${args:?}");
-    let cfg = Config::from(args);
-    compiletest_rs::run_tests(&cfg);
+    let verbose = args.verbose;
+    if verbose {
+        println!("args: ${args:?}");
+    }
+    let config = Config::from(args);
+    if verbose {
+        println!("Compiler: {}", config.program.display());
+    }
+
+    let name = config.root_dir.display().to_string();
+
+    let text = if verbose {
+        status_emitter::Text::verbose()
+    } else {
+        status_emitter::Text::quiet()
+    };
+
+    let result = ui_test::run_tests_generic(
+        vec![config],
+        ui_test::default_file_filter,
+        ui_test::default_per_file_config,
+        (text, status_emitter::Gha::<true> { name }),
+    );
+    if result.is_ok() { ExitCode::SUCCESS } else { ExitCode::FAILURE }
 }

--- a/tools/test-drive/Cargo.toml
+++ b/tools/test-drive/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "test-drive"
+description = "A rustc wrapper that can be used to test stable-mir on a crate"
+version = "0.0.0"
+edition = "2021"
+
+[dependencies]
+
+[package.metadata.rust-analyzer]
+# This crate uses #[feature(rustc_private)].
+# See https://github.com/rust-analyzer/rust-analyzer/pull/7891
+rustc_private = true

--- a/tools/test-drive/build.rs
+++ b/tools/test-drive/build.rs
@@ -1,0 +1,15 @@
+use std::env;
+use std::path::PathBuf;
+
+pub fn main() {
+    // Add rustup to the rpath in order to properly link with the correct rustc version.
+    let rustup_home = env::var("RUSTUP_HOME").unwrap();
+    let toolchain = env::var("RUSTUP_TOOLCHAIN").unwrap();
+    let rustc_lib: PathBuf = [&rustup_home, "toolchains", &toolchain, "lib"]
+        .iter()
+        .collect();
+    println!(
+        "cargo:rustc-link-arg-bin=test-drive=-Wl,-rpath,{}",
+        rustc_lib.display()
+    );
+}

--- a/tools/test-drive/src/main.rs
+++ b/tools/test-drive/src/main.rs
@@ -1,0 +1,88 @@
+//! Test that users are able to inspec the MIR body of functions and types
+
+#![feature(rustc_private)]
+#![feature(assert_matches)]
+#![feature(result_option_inspect)]
+
+mod sanity_checks;
+
+extern crate rustc_middle;
+extern crate rustc_smir;
+
+use rustc_middle::ty::TyCtxt;
+use rustc_smir::{rustc_internal, stable_mir};
+use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::process::ExitCode;
+
+const CHECK_ARG: &str = "--check-smir";
+
+type TestResult = Result<(), String>;
+
+/// This is a wrapper that can be used to replace rustc.
+///
+/// Besides all supported rustc arguments, use `--check-smir` to run all the stable-mir checks.
+/// This allows us to use this tool in cargo projects to analyze the target crate only by running
+/// `cargo rustc --check-smir`.
+fn main() -> ExitCode {
+    let mut check_smir = false;
+    let args: Vec<_> = std::env::args()
+        .filter(|arg| {
+            let is_check_arg = arg == CHECK_ARG;
+            check_smir |= is_check_arg;
+            !is_check_arg
+        })
+        .collect();
+
+
+    let callback = if check_smir { test_stable_mir } else { |_: TyCtxt| ExitCode::SUCCESS };
+    let result = rustc_internal::StableMir::new(args, callback).continue_compilation().run();
+    if let Ok(test_result) = result {
+        test_result
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+macro_rules! run_tests {
+    ($( $test:path ),+) => {
+        [$({
+            run_test(stringify!($test), || { $test() })
+        },)+]
+    };
+}
+
+/// This function invoke other tests and process their results.
+/// Tests should avoid panic,
+fn test_stable_mir(tcx: TyCtxt<'_>) -> ExitCode {
+    let results = run_tests![
+        sanity_checks::test_entry_fn,
+        sanity_checks::test_all_fns,
+        sanity_checks::test_traits,
+        sanity_checks::test_crates
+    ];
+    let (success, failure): (Vec<_>, Vec<_>) = results.iter().partition(|r| r.is_ok());
+    println!(
+        "Ran {} tests. {} succeeded. {} failed",
+        results.len(),
+        success.len(),
+        failure.len()
+    );
+    if failure.is_empty() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    }
+}
+
+fn run_test<F: FnOnce() -> TestResult>(name: &str, f: F) -> TestResult {
+    let result = match catch_unwind(AssertUnwindSafe(f)) {
+        Err(_) => Err("Panic: {}".to_string()),
+        Ok(result) => result,
+    };
+    println!(
+        "Test {}: {}",
+        name,
+        result.as_ref().err().unwrap_or(&"Ok".to_string())
+    );
+    result
+}

--- a/tools/test-drive/src/main.rs
+++ b/tools/test-drive/src/main.rs
@@ -12,10 +12,10 @@ extern crate rustc_smir;
 use rustc_middle::ty::TyCtxt;
 use rustc_smir::rustc_internal;
 use rustc_smir::stable_mir::CompilerError;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::ops::ControlFlow;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::process::ExitCode;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 const CHECK_ARG: &str = "--check-smir";
 const VERBOSE_ARG: &str = "--verbose";
@@ -38,7 +38,10 @@ fn main() -> ExitCode {
             !is_check_arg
         })
         .collect();
-    VERBOSE.store(args.iter().any(|arg| &*arg == VERBOSE_ARG), Ordering::Relaxed);
+    VERBOSE.store(
+        args.iter().any(|arg| &*arg == VERBOSE_ARG),
+        Ordering::Relaxed,
+    );
     let callback = if check_smir {
         test_stable_mir
     } else {
@@ -62,7 +65,8 @@ macro_rules! run_tests {
 
 fn info(msg: String) {
     if VERBOSE.load(Ordering::Relaxed) {
-        println!("{}", msg);
+        // We filter output based on [T-DRIVE] prefix.
+        eprintln!("[T-DRIVE] {}", msg);
     }
 }
 

--- a/tools/test-drive/src/sanity_checks.rs
+++ b/tools/test-drive/src/sanity_checks.rs
@@ -4,9 +4,7 @@
 //! These checks should only depend on StableMIR APIs. See other modules for tests that compare
 //! the result between StableMIR and internal APIs.
 use crate::TestResult;
-use rustc_middle::ty::TyCtxt;
 use rustc_smir::stable_mir;
-use std::collections::HashSet;
 use std::fmt::Debug;
 use std::hint::black_box;
 
@@ -36,6 +34,7 @@ pub fn check(val: bool, msg: String) -> TestResult {
 pub fn test_entry_fn() -> TestResult {
     let entry_fn = stable_mir::entry_fn();
     entry_fn.map_or(Ok(()), |entry_fn| {
+        check_body(entry_fn.body());
         let all_items = stable_mir::all_local_items();
         check(
             all_items.contains(&entry_fn),
@@ -52,6 +51,8 @@ pub fn test_all_fns() -> TestResult {
         "Failed to find any local item".to_string(),
     )?;
 
+    // Not sure which API to use to make sure this is a function that has a body.
+    #[cfg(skip)]
     for item in all_items {
         // Get body and iterate over items
         let body = item.body();

--- a/tools/test-drive/src/sanity_checks.rs
+++ b/tools/test-drive/src/sanity_checks.rs
@@ -43,15 +43,9 @@ pub fn test_entry_fn() -> TestResult {
     })
 }
 
-/// Check that the crate isn't empty and iterate over function bodies.
+/// Iterate over local function bodies.
 pub fn test_all_fns() -> TestResult {
     let all_items = stable_mir::all_local_items();
-    check(
-        !all_items.is_empty(),
-        "Failed to find any local item".to_string(),
-    )?;
-
-    // Not sure which API to use to make sure this is a function that has a body.
     for item in all_items {
         // Get body and iterate over items
         let body = item.body();
@@ -60,10 +54,11 @@ pub fn test_all_fns() -> TestResult {
     Ok(())
 }
 
-/// FIXME: Create <issue> to track improvements to TraitDecls / ImplTraitDecls.
 /// Using these structures will always follow calls to get more details about those structures.
 /// Unless user is trying to find a specific type, this will get repetitive.
 pub fn test_traits() -> TestResult {
+    // FIXME: All trait declarations only return local traits.
+    // See https://github.com/rust-lang/project-stable-mir/issues/37
     let all_traits = stable_mir::all_trait_decls();
     for trait_decl in all_traits.iter().map(stable_mir::trait_decl) {
         // Can't compare trait_decl, so just compare a field for now.

--- a/tools/test-drive/src/sanity_checks.rs
+++ b/tools/test-drive/src/sanity_checks.rs
@@ -52,7 +52,6 @@ pub fn test_all_fns() -> TestResult {
     )?;
 
     // Not sure which API to use to make sure this is a function that has a body.
-    #[cfg(skip)]
     for item in all_items {
         // Get body and iterate over items
         let body = item.body();

--- a/tools/test-drive/src/sanity_checks.rs
+++ b/tools/test-drive/src/sanity_checks.rs
@@ -1,0 +1,121 @@
+//! Module that contains sanity checks that Stable MIR APIs don't crash and that
+//! their result is coherent.
+//!
+//! These checks should only depend on StableMIR APIs. See other modules for tests that compare
+//! the result between StableMIR and internal APIs.
+use crate::TestResult;
+use rustc_middle::ty::TyCtxt;
+use rustc_smir::stable_mir;
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::hint::black_box;
+
+fn check_equal<T>(val: T, expected: T, msg: &str) -> TestResult
+where
+    T: Debug + PartialEq,
+{
+    if val != expected {
+        Err(format!(
+            "{}: \n Expected: {:?}\n Found: {:?}",
+            msg, expected, val
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+pub fn check(val: bool, msg: String) -> TestResult {
+    if !val {
+        Err(msg)
+    } else {
+        Ok(())
+    }
+}
+
+// Test that if there is an entry point, the function is part of `all_local_items`.
+pub fn test_entry_fn() -> TestResult {
+    let entry_fn = stable_mir::entry_fn();
+    entry_fn.map_or(Ok(()), |entry_fn| {
+        let all_items = stable_mir::all_local_items();
+        check(
+            all_items.contains(&entry_fn),
+            format!("Failed to find entry_fn `{:?}`", entry_fn),
+        )
+    })
+}
+
+/// Check that the crate isn't empty and iterate over function bodies.
+pub fn test_all_fns() -> TestResult {
+    let all_items = stable_mir::all_local_items();
+    check(
+        !all_items.is_empty(),
+        "Failed to find any local item".to_string(),
+    )?;
+
+    for item in all_items {
+        // Get body and iterate over items
+        let body = item.body();
+        check_body(body);
+    }
+    Ok(())
+}
+
+/// FIXME: Create <issue> to track improvements to TraitDecls / ImplTraitDecls.
+/// Using these structures will always follow calls to get more details about those structures.
+/// Unless user is trying to find a specific type, this will get repetitive.
+pub fn test_traits() -> TestResult {
+    let all_traits = stable_mir::all_trait_decls();
+    for trait_decl in all_traits.iter().map(stable_mir::trait_decl) {
+        // Can't compare trait_decl, so just compare a field for now.
+        check_equal(
+            stable_mir::trait_decl(&trait_decl.def_id).specialization_kind,
+            trait_decl.specialization_kind,
+            "external crate mismatch",
+        )?;
+    }
+
+    for trait_impl in stable_mir::all_trait_impls()
+        .iter()
+        .map(stable_mir::trait_impl)
+    {
+        check(
+            all_traits.contains(&trait_impl.value.def_id),
+            format!("Failed to find trait definition {trait_impl:?}"),
+        )?;
+    }
+    Ok(())
+}
+
+pub fn test_crates() -> TestResult {
+    for krate in stable_mir::external_crates() {
+        check_equal(
+            stable_mir::find_crate(&krate.name.as_str()),
+            Some(krate),
+            "external crate mismatch",
+        )?;
+    }
+
+    let local = stable_mir::local_crate();
+    check_equal(
+        stable_mir::find_crate(&local.name.as_str()),
+        Some(local),
+        "local crate mismatch",
+    )
+}
+
+/// Visit all local types, statements and terminator to ensure nothing crashes.
+fn check_body(body: stable_mir::mir::Body) {
+    for bb in body.blocks {
+        for stmt in bb.statements {
+            black_box(matches!(stmt, stable_mir::mir::Statement::Assign(..)));
+        }
+        black_box(matches!(
+            bb.terminator,
+            stable_mir::mir::Terminator::Goto { .. }
+        ));
+    }
+
+    for local in body.locals {
+        black_box(matches!(local.kind(), stable_mir::ty::TyKind::Alias(..)));
+    }
+}


### PR DESCRIPTION
Create two different tools:

  - `test-drive`: A rustc_driver that compiles a crate and run a few sanity checks on StableMIR.
  - `compiletest`: A wrapper to run compiler tests using the `test-drive` tool.

I am also adding a script to run a few rustc tests and a nightly workflow. The files diff is not quite working yet so most tests that fail compilation don't succeed yet.

For our local tests, so far I created two suites (one with a test each): sanity-checks and fixme suite. The fixme suite is for issues that we find that needs fixing. I found an issue on the Trait API. I haven't debugged it yet.