### PR TITLE
Fix tests after nightly breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 -->
 ![project group status: active](https://img.shields.io/badge/status-active-brightgreen.svg)
 [![project group documentation](https://img.shields.io/badge/MDBook-View%20Documentation-blue)][gh-pages]
+[![Run compiler tests](https://github.com/rust-lang/project-stable-mir/actions/workflows/nightly.yml/badge.svg)](https://github.com/rust-lang/project-stable-mir/actions/workflows/nightly.yml)
 
 
 <!--
@@ -47,4 +48,3 @@ yourself over there and ask us any questions you have.
 [open issues]: https://github.com/rust-lang/project-stable-mir/issues
 [chat-link]: https://rust-lang.zulipchat.com/#narrow/stream/320896-project-stable-mir
 [team-toml]: https://github.com/rust-lang/team/blob/master/teams/project-stable-mir.toml
-

--- a/tools/test-drive/src/main.rs
+++ b/tools/test-drive/src/main.rs
@@ -8,10 +8,11 @@ mod sanity_checks;
 
 extern crate rustc_middle;
 extern crate rustc_smir;
+extern crate stable_mir;
 
 use rustc_middle::ty::TyCtxt;
 use rustc_smir::rustc_internal;
-use rustc_smir::stable_mir::CompilerError;
+use stable_mir::CompilerError;
 use std::ops::ControlFlow;
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::process::ExitCode;


### PR DESCRIPTION
Fix `test-drive` compilation errors caused by non-backward compatible changes to move `stable_mir` crate, to add `Span` and to fix `find_crate` behavior.

I also added a badge to the README.md to give a bit more visibility to our tests.