### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,13 @@ This is the repository we use to organise our work. Please refer to our [charter
 as our [github pages website][gh-pages] for more information on our goals and
 current scope.
 
-If you are wondering how to use Stable MIR in your project, also see the [rustc_smir crate][rustc_smir].
+If you are wondering how to use Stable MIR in your project, check the `stable_mir` crate [source code][stable_mir]
+and [documentation][stable_mir_doc].
 
 [charter]: ./CHARTER.md
 [gh-pages]: https://rust-lang.github.io/project-stable-mir
-[rustc_smir]: https://github.com/rust-lang/rust/tree/master/compiler/rustc_smir
+[stable_mir]: https://github.com/rust-lang/rust/tree/master/compiler/stable_mir
+[stable_mir_doc]: https://doc.rust-lang.org/beta/nightly-rustc/stable_mir/index.html
 
 
 ## How Can I Get Involved?


### PR DESCRIPTION
Link to `stable_mir` crate instead of `rustc_smir`